### PR TITLE
Auto-install hooks on first launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to cookinn.notch will be documented in this file.
 
+## [0.1.1] - 2025-01-08
+
+### Changed
+- Hooks now auto-install on first launch (no setup click required)
+- Onboarding window only appears if installation fails
+- Manual setup still available via menu bar → "Setup..."
+
+### Added
+- Documentation for hooks configuration (`docs/hooks.md`)
+- Documentation for slash commands (`docs/skills.md`)
+
 ## [0.1.0] - 2025-01-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -47,6 +47,11 @@ Download the latest `.dmg` from [Releases](https://github.com/ojowwalker77/cooki
 - Context window usage
 - Activity patterns
 
+## Documentation
+
+- [Hooks Configuration](docs/hooks.md) - How Claude Code hooks work
+- [Slash Commands](docs/skills.md) - `/send-to-notch` and `/remove-from-notch`
+
 ## Requirements
 
 - macOS 15.0 (Sequoia) or later

--- a/cookinn.notch/cookinn_notchApp.swift
+++ b/cookinn.notch/cookinn_notchApp.swift
@@ -381,7 +381,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate {
         let status = await SetupManager.shared.checkSetup()
 
         if status == .notInstalled || status == .needsUpdate {
-            showOnboardingWindow()
+            // Auto-install hooks silently
+            let success = await SetupManager.shared.installHooks()
+
+            // Only show onboarding if installation failed
+            if !success {
+                showOnboardingWindow()
+            }
         }
     }
 

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,122 @@
+# Hooks Configuration
+
+cookinn.notch uses Claude Code hooks to receive activity events. The app auto-installs these on first launch, but you can also configure them manually.
+
+## Automatic Setup
+
+Hooks are automatically installed when you first launch the app. If you need to reinstall, use the menu bar icon → "Setup..."
+
+## Manual Setup
+
+Add the following to your `~/.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/cookinn-notch/notch-hook.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/cookinn-notch/notch-hook.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/cookinn-notch/notch-hook.sh"
+          }
+        ]
+      }
+    ],
+    "SubagentStop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/cookinn-notch/notch-hook.sh"
+          }
+        ]
+      }
+    ],
+    "Notification": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/cookinn-notch/notch-hook.sh"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/cookinn-notch/notch-hook.sh"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/cookinn-notch/notch-hook.sh"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.config/cookinn-notch/notch-hook.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Hook Events
+
+| Event | Description |
+|-------|-------------|
+| `PreToolUse` | Tool is about to be executed |
+| `PostToolUse` | Tool has finished executing |
+| `Stop` | Claude stopped responding |
+| `SubagentStop` | A subagent task completed |
+| `Notification` | Claude sent a notification |
+| `SessionStart` | New Claude Code session started |
+| `SessionEnd` | Session ended |
+| `UserPromptSubmit` | User submitted a prompt |
+
+## Files
+
+After installation, these files exist in `~/.config/cookinn-notch/`:
+
+```
+~/.config/cookinn-notch/
+├── notch-hook.sh       # Main hook script (receives events)
+├── send-to-notch.sh    # Pin current session
+└── remove-from-notch.sh # Unpin all sessions
+```

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,0 +1,62 @@
+# Slash Commands (Skills)
+
+cookinn.notch installs two slash commands for Claude Code.
+
+## /send-to-notch
+
+Pin the current Claude Code session to the notch display.
+
+```
+/send-to-notch
+```
+
+This runs `~/.config/cookinn-notch/send-to-notch.sh` which sends a pin request to the app.
+
+## /remove-from-notch
+
+Unpin all sessions from the notch display.
+
+```
+/remove-from-notch
+```
+
+This runs `~/.config/cookinn-notch/remove-from-notch.sh` which clears all pinned sessions.
+
+## Manual Installation
+
+If commands aren't installed automatically, create these files:
+
+### ~/.claude/commands/send-to-notch.md
+
+```markdown
+Pin this Claude Code session to the cookinn.notch display.
+
+Run this command:
+\`\`\`bash
+~/.config/cookinn-notch/send-to-notch.sh
+\`\`\`
+
+Then confirm to the user that the session has been pinned to the notch display.
+```
+
+### ~/.claude/commands/remove-from-notch.md
+
+```markdown
+Unpin all sessions from the cookinn.notch display.
+
+Run this command:
+\`\`\`bash
+~/.config/cookinn-notch/remove-from-notch.sh
+\`\`\`
+
+Then confirm to the user that the sessions have been unpinned from the notch display.
+```
+
+## How It Works
+
+The commands communicate with cookinn.notch via HTTP on `localhost:27182`:
+
+- **Pin**: `POST /pin` with session info from environment variables
+- **Unpin**: `POST /unpin` to clear all pinned sessions
+
+The app maintains a list of pinned project paths and only displays activity from those sessions.


### PR DESCRIPTION
## Summary
- Hooks now auto-install silently on first launch
- Onboarding window only shows if installation fails
- Manual setup still available via menu bar → "Setup..."

## Added
- `docs/hooks.md` - Hooks configuration examples
- `docs/skills.md` - Slash command documentation

## Test plan
- [ ] Fresh install via brew
- [ ] Verify hooks auto-install without user interaction
- [ ] Verify `/send-to-notch` works immediately after install