### PR TITLE
Add monitor picker and fix performance issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to cookinn.notch will be documented in this file.
 
+## [0.1.2] - 2025-01-08
+
+### Added
+- Monitor picker: select which display to show the notch on
+- Open at Login option with first-launch prompt
+
+### Changed
+- Replaced "Show on All Monitors" toggle with Display submenu
+- Performance improvements for smoother animations
+
 ## [0.1.1] - 2025-01-08
 
 ### Changed


### PR DESCRIPTION
## Summary
- Replace "Show on All Monitors" toggle with a Display submenu for selecting specific monitors
- Fix critical memory leaks and performance issues

## Features

### Monitor Picker
- New "Display" submenu lists all connected monitors
- "All Monitors" option to show on all screens
- Individual monitor selection with checkmark indicator
- Selection persists across app restarts via UserDefaults
- Graceful fallback to main screen if selected monitor disconnects
- Menu updates dynamically when monitors are added/removed

### Performance Fixes
- **Timer leaks fixed**: SessionCard and ActivityIndicator timers now properly stop when views disappear
- **Status timer fixed**: Replaced recursive `asyncAfter` with managed Timer that's invalidated on termination
- **Mouse throttling**: Added 60fps throttle to global mouse monitor (was running on every mouse move)
- **Optimized state updates**: Only dispatch main thread Tasks when state actually changes

## Test plan
- [ ] Single monitor: Default shows on main screen
- [ ] Multi-monitor: Display submenu lists all connected monitors
- [ ] Selection: Checkmark appears on selected monitor, notch moves
- [ ] Disconnect: Removing selected monitor falls back to main
- [ ] Persistence: Selection survives app restart
- [ ] Memory: Monitor memory over time - should stay stable (~120MB)
- [ ] CPU: Should be low when idle, no spikes during mouse movement